### PR TITLE
Fix a logging message in ua_client_connect.c

### DIFF
--- a/src/client/ua_client_connect.c
+++ b/src/client/ua_client_connect.c
@@ -1054,7 +1054,7 @@ responseFindServers(UA_Client *client, void *userdata,
         for(size_t j = 0; j < server->discoveryUrlsSize; j++) {
             if(UA_String_equal(&client->config.endpointUrl, &server->discoveryUrls[j])) {
                 UA_LOG_INFO(&client->config.logger, UA_LOGCATEGORY_CLIENT,
-                            "The initially defined EndpointURL %.*s"
+                            "The initially defined EndpointURL %.*s "
                             "is valid for the server",
                             (int)client->config.endpointUrl.length,
                             client->config.endpointUrl.data);


### PR DESCRIPTION
Add missing space to a log message.

Currently is prints
`The initially defined EndpointURL opc.tcp://127.0.0.1:49320is valid for the server`